### PR TITLE
RabbitMQ 3.7 Compatibility

### DIFF
--- a/pyrabbit2/api.py
+++ b/pyrabbit2/api.py
@@ -692,6 +692,13 @@ class Client(object):
 
         vhost = quote(vhost, '')
         base_body = {'count': count, 'requeue': requeue, 'encoding': encoding}
+
+        # 3.7.X now uses ackmode to denote the requeuing capability
+        if requeue:
+            base_body['ackmode'] = 'ack_requeue_true'
+        else:
+            base_body['ackmode'] = 'ack_requeue_false'
+
         if truncate:
             base_body['truncate'] = truncate
         body = json.dumps(base_body)

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -5,7 +5,7 @@ except ImportError:
 
 import sys
 sys.path.append('..')
-from pyrabbit import http
+from pyrabbit2 import http
 
 
 

--- a/tests/test_pyrabbit.py
+++ b/tests/test_pyrabbit.py
@@ -15,16 +15,20 @@ sys.path.append('..')
 import pyrabbit2
 from mock import Mock, patch
 
+host_and_port = 'localhost:15672'
+user = 'guest'
+password = 'guest'
+
 class TestClient(unittest.TestCase):
     def setUp(self):
-        self.client = pyrabbit2.api.Client('localhost:15672', 'guest', 'guest')
+        self.client = pyrabbit2.api.Client(host_and_port, user, password)
 
     def tearDown(self):
         del self.client
 
     def test_server_init_200(self):
         self.assertIsInstance(self.client, pyrabbit2.api.Client)
-        self.assertEqual(self.client.api_url, 'localhost:15672')
+        self.assertEqual(self.client.api_url, host_and_port)
 
     def test_server_is_alive_default_vhost(self):
         response = {'status': 'ok'}
@@ -214,7 +218,7 @@ class TestClient(unittest.TestCase):
 
 class TestLiveServer(unittest.TestCase):
     def setUp(self):
-        self.rabbit = pyrabbit2.api.Client('localhost:15672', 'guest', 'guest')
+        self.rabbit = pyrabbit2.api.Client(host_and_port, user, password)
         self.vhost_name = 'pyrabbit_test_vhost'
         self.exchange_name = 'pyrabbit_test_exchange'
         self.queue_name = 'pyrabbit_test_queue'
@@ -285,7 +289,7 @@ class TestLiveServer(unittest.TestCase):
 class TestShovel(unittest.TestCase):
 
     def setUp(self):
-        self.rabbit = pyrabbit2.api.Client('localhost:15672', 'guest', 'guest')
+        self.rabbit = pyrabbit2.api.Client(host_and_port, user, password)
         self.vhost_name = '/'
         self.exchange_name = 'pyrabbit_test_exchange'
         self.queue_name = 'pyrabbit_test_queue'

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,24 @@ envlist = py26,py27,py34,py35,py36
 
 [testenv:py36]
 deps=
+    nose
     requests
+    mock
+commands=nosetests []
 
 [testenv:py35]
 deps=
+    nose
     requests
+    mock
+commands=nosetests []
 
 [testenv:py34]
 deps=
+    nose
     requests
+    mock
+commands=nosetests []
 
 [testenv:py27]
 deps=


### PR DESCRIPTION
## Changes:

This merge request is to add support for RabbitMQ 3.7.

As far as I can tell there is only one part of the API that needed
to be updated. The requeue flag became `ackmode: requeue_true`
in 3.7.X from `requeue: true`. 

## Tested on/using:

* RabbitMQ 3.5.8 - installed via RPM
* RabbitMQ 3.6.15 - installed via Docker
* RabbitMQ 3.7.2 - installed via Docker

## Testing Changes:

I had to modify tox to actually run the tests in python34, 35 and 36.
It is possible I just missed something and these were running, but 
they didn't appear to be running on my machine.

In one test, it was attempting to import `pyrabbit` instead of 
`pyrabbit2`, so I modified that as well.

