### PR TITLE
Allow filtering for fetching queues

### DIFF
--- a/pyrabbit2/api.py
+++ b/pyrabbit2/api.py
@@ -114,13 +114,13 @@ class Client(object):
 
         return
 
-    def _call(self, path, method, body=None, headers=None):
+    def _call(self, path, method, body=None, headers=None, params=None):
         """
         Wrapper around http.do_call that transforms some HTTPError into
         our own exceptions
         """
         try:
-            resp = self.http.do_call(path, method, body, headers)
+            resp = self.http.do_call(path, method, body, headers, params)
         except http.HTTPError as err:
             if err.status == 401:
                 raise PermissionError('Insufficient permissions to query ' +

--- a/pyrabbit2/api.py
+++ b/pyrabbit2/api.py
@@ -604,13 +604,23 @@ class Client(object):
         else:
             path = Client.urls['all_queues']
 
-        params = None
         if pattern:
+            cur_page = 1
+            num_pages = 1
+            queues = list()
             params = {
-                'use_regex': regex,
+                'use_regex': 'true' if regex else 'false',
                 'name': pattern,
+                'pagination': True,
             }
-        queues = self._call(path, 'GET', params=params)
+            while cur_page <= num_pages:
+                params['page'] = cur_page
+                result = self._call(path, 'GET', params=params)
+                queues.extend(result['items'])
+                cur_page += 1
+                num_pages = result['page_count']
+        else:
+            queues = self._call(path, 'GET')
         return queues or list()
 
     def get_queue(self, vhost, name):

--- a/pyrabbit2/api.py
+++ b/pyrabbit2/api.py
@@ -584,7 +584,7 @@ class Client(object):
     #############################################
     #               QUEUES
     #############################################
-    def get_queues(self, vhost=None):
+    def get_queues(self, vhost=None, pattern=None, regex=False):
         """
         Get all queues, or all queues in a vhost if vhost is not None.
         Returns a list.
@@ -592,6 +592,8 @@ class Client(object):
         :param string vhost: The virtual host to list queues for. If This is
                     None (the default), all queues for the broker instance
                     are returned.
+        :param string pattern: Name pattern to filter queues
+        :param boolean regex: True if pattern is regex
         :returns: A list of dicts, each representing a queue.
         :rtype: list of dicts
 
@@ -602,7 +604,13 @@ class Client(object):
         else:
             path = Client.urls['all_queues']
 
-        queues = self._call(path, 'GET')
+        params = None
+        if pattern:
+            params = {
+                'use_regex': regex,
+                'name': pattern,
+            }
+        queues = self._call(path, 'GET', params=params)
         return queues or list()
 
     def get_queue(self, vhost, name):

--- a/pyrabbit2/http.py
+++ b/pyrabbit2/http.py
@@ -74,7 +74,7 @@ class HTTPClient(object):
         self.verify = verify
         self.cert = cert
 
-    def do_call(self, path, method, body=None, headers=None):
+    def do_call(self, path, method, body=None, headers=None, params=None):
         """
         Send an HTTP request to the REST API.
 
@@ -85,13 +85,15 @@ class HTTPClient(object):
             body of the HTTP request.
         :param dictionary headers:
             "{header-name: header-value}" dictionary.
+        :param dictionary params: query parameters
 
         """
         url = urljoin(self.base_url, path)
         try:
             resp = requests.request(method, url, data=body, headers=headers,
                                     auth=self.auth, timeout=self.timeout,
-                                    verify=self.verify, cert=self.cert)
+                                    verify=self.verify, cert=self.cert,
+                                    params=params)
         except requests.exceptions.Timeout as out:
             raise NetworkError("Timeout while trying to connect to RabbitMQ")
         except requests.exceptions.RequestException as err:


### PR DESCRIPTION
Sometimes during federation queues recreation RabbitMQ returns 500 instead of queues list. But if federation queues are filtered out request works.

This PR introduces changes to `get_queues` method to allow queues filtering on broker side