### PR TITLE
fix doc example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ great w/ Python 3!
 Here's a quick demo::
 
     >>> from pyrabbit.api import Client
-    >>> cl = Client('localhost:55672/api', 'guest', 'guest')
+    >>> cl = Client('localhost:55672', 'guest', 'guest')
     >>> cl.is_alive()
     True
     >>> cl.create_vhost('example_vhost')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ great w/ Python 3!
 Here's a quick demo::
 
     >>> from pyrabbit.api import Client
-    >>> cl = Client('http://localhost:55672/api', 'guest', 'guest')
+    >>> cl = Client('localhost:55672/api', 'guest', 'guest')
     >>> cl.is_alive()
     True
     >>> cl.create_vhost('example_vhost')


### PR DESCRIPTION
fix doc example because of:

https://github.com/deslum/pyrabbit2/blob/master/pyrabbit2/http.py#L58 
> scheme='http'

https://github.com/deslum/pyrabbit2/blob/master/pyrabbit2/http.py#L72

> api_url = '%s://%s/api/' % (scheme, api_url)